### PR TITLE
Expose typecheck in the client

### DIFF
--- a/example/example.ml
+++ b/example/example.ml
@@ -16,12 +16,18 @@ let log_output (o : Toplevel_api_gen.exec_result) =
   Option.iter (fun s -> log ("stderr: " ^ s)) o.stderr;
   Option.iter (fun s -> log ("sharp_ppf: " ^ s)) o.sharp_ppf;
   Option.iter (fun s -> log ("caml_ppf: " ^ s)) o.caml_ppf;
-  let strloc (line,col) =
+  let strloc (line, col) =
     "(" ^ string_of_int line ^ "," ^ string_of_int col ^ ")"
   in
-  Option.iter (fun h ->
-    let open Toplevel_api_gen in
-    log ("highlight " ^ strloc (h.line1, h.col1) ^ " to " ^ strloc (h.line2, h.col2))) o.highlight
+  Option.iter
+    (fun h ->
+      let open Toplevel_api_gen in
+      log
+        ("highlight "
+        ^ strloc (h.line1, h.col1)
+        ^ " to "
+        ^ strloc (h.line2, h.col2)))
+    o.highlight
 
 let _ =
   let ( let* ) = Lwt_result.bind in

--- a/idl/js_top_worker_client.ml
+++ b/idl/js_top_worker_client.ml
@@ -76,6 +76,11 @@ module W : sig
     unit ->
     (Toplevel_api_gen.exec_result, Toplevel_api_gen.err) result Lwt.t
 
+  val typecheck :
+    rpc ->
+    string ->
+    (Toplevel_api_gen.exec_result, Toplevel_api_gen.err) result Lwt.t
+
   val exec :
     rpc ->
     string ->
@@ -93,6 +98,7 @@ end = struct
 
   let init rpc a = Wraw.init rpc a |> Rpc_lwt.T.get
   let setup rpc a = Wraw.setup rpc a |> Rpc_lwt.T.get
+  let typecheck rpc a = Wraw.typecheck rpc a |> Rpc_lwt.T.get
   let exec rpc a = Wraw.exec rpc a |> Rpc_lwt.T.get
   let complete rpc a = Wraw.complete rpc a |> Rpc_lwt.T.get
 end

--- a/idl/js_top_worker_client.mli
+++ b/idl/js_top_worker_client.mli
@@ -45,9 +45,13 @@ module W : sig
       printed when starting a toplevel. Note that the toplevel
       must be initialised first. *)
 
+  val typecheck : rpc -> string -> (exec_result, err) result Lwt.t
+  (** Typecheck a phrase using the toplevel. The toplevel must have been
+      initialised first. *)
+
   val exec : rpc -> string -> (exec_result, err) result Lwt.t
   (** Execute a phrase using the toplevel. The toplevel must have been
-      Initialised first. *)
+      initialised first. *)
 
   val complete : rpc -> string -> (completion_result, err) result Lwt.t
   (** Find completions of the incomplete phrase. Completion occurs at the

--- a/idl/toplevel_api.ml
+++ b/idl/toplevel_api.ml
@@ -33,7 +33,6 @@ type cma = {
 [@@deriving rpcty]
 
 type init_libs = { cmi_urls : string list; cmas : cma list } [@@deriving rpcty]
-
 type err = InternalError of string [@@deriving rpcty]
 
 module E = Idl.Error.Make (struct
@@ -90,8 +89,7 @@ module Make (R : RPC) = struct
       (unit_p @-> returning exec_result_p err)
 
   let typecheck =
-    declare
-      "typecheck"
+    declare "typecheck"
       [ "Typecheck a phrase without actually executing it." ]
       (phrase_p @-> returning typecheck_result_p err)
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,5 @@
 ; Worker library
+
 (rule
  (targets worker.ml)
  (deps


### PR DESCRIPTION
I saw that the `typecheck` was added, thank you 🚀 ! 

To use it in v3 just need to expose it in the client interface (I think a few extra changes came along after a format).