### PR TITLE
Make sure websocket is ready

### DIFF
--- a/idl/dune
+++ b/idl/dune
@@ -5,10 +5,16 @@
  (libraries rresult mime_printer))
 
 (library
+ (name jsonrpc)
+ (public_name js_top_worker-rpc.jsonrpc)
+ (modules jsonrpc)
+ (libraries js_top_worker-rpc yojson rresult mime_printer))
+
+(library
  (name js_top_worker_client)
  (public_name js_top_worker-client)
- (modules js_top_worker_client jsonrpc)
- (libraries js_top_worker-rpc lwt brr yojson))
+ (modules js_top_worker_client)
+ (libraries js_top_worker-rpc js_top_worker-rpc.jsonrpc  lwt brr yojson))
 
 (library
  (name js_top_worker_rpc_def)


### PR DESCRIPTION
This moves jsonrpc out of the client and makes sure the websocket connection is open before trying to send messages.